### PR TITLE
Add governance foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a reproducible problem with the Python client
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+
+## Environment
+
+- Python version:
+- Package version or commit:
+- Operating system:
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Additional Context
+
+Do not include real PrintNode API keys, account credentials, or customer data.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: PrintNode API Documentation
+    url: https://www.printnode.com/en/docs/api/curl
+    about: Reference documentation for the PrintNode API.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or missing PrintNode API capability
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+
+## Use Case
+
+
+## Proposed Behavior
+
+
+## Compatibility Notes
+
+
+## Additional Context
+
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+- 
+
+## Type of Change
+
+- [ ] Documentation or governance
+- [ ] Tests only
+- [ ] Bug fix
+- [ ] Packaging or tooling
+- [ ] CI or release workflow
+- [ ] Breaking change
+
+## Verification
+
+- [ ] I ran the relevant tests locally
+- [ ] I updated or added tests where appropriate
+- [ ] I updated documentation where appropriate
+- [ ] CI is expected to pass
+
+Commands run:
+
+```sh
+
+```
+
+Commands not run, with reason:
+
+```text
+
+```
+
+## Compatibility Notes
+
+- 
+
+## Release Notes
+
+- 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+## Project Mission
+
+This repository is maintained as a careful, community-oriented Python client for the PrintNode API. Prioritize correctness, compatibility, clear releases, and a learning-friendly development workflow.
+
+## Branch and PR Rules
+
+- The default branch is `main`.
+- Do not commit directly to `main`.
+- Use a focused branch and pull request for every meaningful change.
+- Keep pull requests small enough to review.
+- Require tests and CI before merge whenever the change affects code, packaging, or release behavior.
+- Treat default-branch migration and repository settings as explicit maintenance tasks.
+- Do not push branches or open pull requests unless the user explicitly asks for that action.
+
+## Python Project Standards
+
+- Use `pyproject.toml` as the project source of truth.
+- Use `uv` for local development, dependency locking, testing, and builds.
+- Keep `uv.lock` committed for reproducible development and CI once `uv` is introduced.
+- Preserve the existing `printnodeapi` import path unless a breaking-change pull request explicitly changes it.
+- Prefer modern Python packaging practices while avoiding unnecessary rewrites.
+
+## Dependency Maintenance
+
+- Keep Dependabot enabled for every dependency surface in the repository.
+- Configure Dependabot for `uv`, GitHub Actions, and `pre-commit` when pre-commit hooks exist.
+- Add new Dependabot ecosystems when new manifests are introduced.
+- Dependabot pull requests must pass the same CI as human pull requests.
+
+## Testing Standards
+
+- The default test suite must not require real PrintNode credentials.
+- Use mocked HTTP tests for normal CI.
+- Gate live PrintNode API tests behind explicit environment variables.
+- Add or update tests for behavior changes.
+- Do not remove coverage just because legacy tests are awkward.
+
+## Release Standards
+
+- Do not publish releases from unreviewed local state.
+- Build and validate distributions before release.
+- Use TestPyPI before first publishing under a new distribution name.
+- Update `CHANGELOG.md` for user-visible changes.
+- Keep release notes clear about whether this is an official PrintNode release or a community-maintained fork.
+- Preserve `printnodeapi` as the import package even if the PyPI distribution name changes.
+
+## Local Verification
+
+Use `uv` by default once the project has been modernized:
+
+```sh
+uv sync
+uv run pytest
+uv build
+uv run twine check dist/*
+```
+
+Until the `uv` migration lands, use the currently available test/build commands and note any missing tooling in the pull request body.
+
+## Code Agent Notes
+
+- Use `rg` or `fd` for searching.
+- Use `apply_patch` for file edits.
+- Do not overwrite user changes.
+- Do not run destructive git commands.
+- Prefer pull-request-backed work and summarize verification clearly.
+- Keep changes boring, reviewable, and well-tested.
+- Update the durable stewardship plan at `~/.codex/plans/printnode-python-stewardship.md` when major phases start, finish, or change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this community-maintained fork will be documented in this file.
+
+The format follows the spirit of Keep a Changelog, and this project intends to use semantic versioning once the first maintained release is cut.
+
+## Unreleased
+
+### Added
+
+- Added repository governance documentation for community maintenance.
+- Added contribution, security, issue, and pull request guidance.
+
+### Changed
+
+- Documented the plan to migrate the default branch from `master` to `main`.
+- Documented the plan to modernize packaging around `pyproject.toml` and `uv`.
+
+### Notes
+
+- This fork is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thank you for helping maintain this PrintNode API client. This fork aims to be careful, compatible, and easy to learn from.
+
+## Workflow
+
+- Open a focused pull request for every meaningful change.
+- Do not commit directly to `main`.
+- Keep changes small and reviewable.
+- Include tests for behavior changes.
+- Update documentation when user-facing behavior changes.
+- Mention any command you could not run in the pull request body.
+
+## Development
+
+The project is being modernized around `pyproject.toml` and `uv`. Until that migration is complete, prefer the commands documented in the current pull request.
+
+Once `uv` is available, the standard local workflow will be:
+
+```sh
+uv sync
+uv run pytest
+```
+
+Build checks will use:
+
+```sh
+uv build
+uv run twine check dist/*
+```
+
+## Tests
+
+Default tests must not require real PrintNode credentials. Use mocked HTTP responses for normal test coverage.
+
+Live PrintNode API tests may be added, but they must be opt-in and gated by environment variables so they never run accidentally in CI or on contributor machines.
+
+## Compatibility
+
+Preserve the existing `printnodeapi` import path. Breaking changes require an explicit pull request, changelog entry, and release note.
+
+## Releases
+
+Releases are cut only from reviewed code that has passed CI. New distribution names must be tested on TestPyPI before publishing to PyPI.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## **PrintNode API Client Python Library**
 
+> [!NOTE]
+> This repository is being prepared as a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The current stewardship plan is to preserve the existing `printnodeapi` import path, migrate the default branch to `main`, modernize packaging with `pyproject.toml` and `uv`, and release only after CI, tests, and package publishing are in good shape.
+
 This is a Python library to interact with PrintNode's remote printing API. This client allows you to access the API's functions for quick use in Python scripts.
 
 ### Requirements

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+This fork is being prepared for a maintained release. Until the first maintained release is published, security fixes target the current `main` branch.
+
+After the first release, supported versions will be documented here and in the release notes.
+
+## Reporting a Vulnerability
+
+Please report suspected security issues privately before opening a public issue when the report includes credentials, tokens, exploit details, or sensitive API behavior.
+
+If GitHub private vulnerability reporting is enabled for this repository, use it. Otherwise, contact the repository maintainer directly through GitHub.
+
+Include:
+
+- affected version or commit;
+- Python version;
+- minimal reproduction steps;
+- expected and actual behavior;
+- whether credentials or live PrintNode API calls are involved.
+
+Do not include real PrintNode API keys, account credentials, or customer data in public issues, pull requests, logs, or test fixtures.


### PR DESCRIPTION
## Summary
- add project-specific agent instructions for PR-first stewardship
- add contribution, security, changelog, issue, and PR templates
- add Dependabot configuration for uv and GitHub Actions
- add a README notice clarifying community-fork status and modernization direction

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); YAML.load_file('.github/ISSUE_TEMPLATE/config.yml')"`\n\n## Notes\n- This is the first governance checkpoint before migrating the default branch from `master` to `main`.\n- Issues are now enabled on the fork.