### PR TITLE
Harden auth request handling

### DIFF
--- a/printnodeapi/auth.py
+++ b/printnodeapi/auth.py
@@ -79,13 +79,13 @@ class Auth:
         other_args = {}
         if fields is not None:
             other_args['data'] = json.dumps(fields)
-        if request_headers is None:
-            request_headers = self._headers
-        else:
-            request_headers.update(self._headers)
+        headers = {}
+        if request_headers is not None:
+            headers.update(request_headers)
+        headers.update(self._headers)
 
         if method == requests.patch:
-            request_headers.update({"Content-Type": "application/json"})
+            headers.update({"Content-Type": "application/json"})
 
         if self._sslcert is not None:
             other_args['verify'] = self._sslcert
@@ -94,11 +94,14 @@ class Auth:
             response = method(
                 url=url,
                 auth=self._auth,
-                headers=request_headers,
+                headers=headers,
                 **other_args)
 
         content_type = response.headers.get('content-type')
-        if content_type != 'application/json':
+        media_type = None
+        if content_type is not None:
+            media_type = content_type.split(';', 1)[0].strip().lower()
+        if media_type != 'application/json':
             template = 'Incorrect Content-Type "{}" for url "{}"'
             raise ValueError(template.format(content_type, url))
         response_obj = response.json()
@@ -213,5 +216,9 @@ class rewrite_requests_error:
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None:
             return
-        exc = self.mapping.get(exc_type, RequestError)
+        exc = RequestError
+        for request_exc, network_exc in self.mapping.items():
+            if issubclass(exc_type, request_exc):
+                exc = network_exc
+                break
         raise_from(exc(str(exc_value)), exc_value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,17 @@
-import pytest
+import json
 
+import pytest
+import requests
+
+from printnodeapi.auth import (
+    Auth,
+    ClientError,
+    ConnectionError,
+    RequestError,
+    ServerError,
+    TimeoutError,
+    TooManyRequests,
+)
 from printnodeapi.gateway import Gateway, Unauthorized
 
 API_ADDRESS = 'https://api.printnode.com'
@@ -7,10 +19,10 @@ API_KEY = 'test-api-key'
 
 
 class FakeResponse:
-    def __init__(self, status_code, payload):
+    def __init__(self, status_code, payload, content_type='application/json'):
         self.status_code = status_code
         self._payload = payload
-        self.headers = {'content-type': 'application/json'}
+        self.headers = {'content-type': content_type}
 
     def json(self):
         return self._payload
@@ -61,3 +73,221 @@ def test_gateway_handles_unauthentication(monkeypatch):
         password='helloworld')
     with pytest.raises(Unauthorized):
         gateway.account
+
+
+@pytest.mark.parametrize('kwargs,expected_auth,expected_headers', [
+    ({'apikey': 'api-key'}, ('api-key', ''), {}),
+    (
+        {'email': 'ada@example.com', 'password': 'secret'},
+        ('ada@example.com', 'secret'),
+        {'X-Auth-With-Account-Credentials': 'API'},
+    ),
+    (
+        {'clientkey': 'client-key'},
+        ('client-key', ''),
+        {'X-Auth-With-Client-Key': 'API'},
+    ),
+    (
+        {'apikey': 'api-key', 'child_email': 'child@example.com'},
+        ('api-key', ''),
+        {'X-Child-Account-By-Email': 'child@example.com'},
+    ),
+    (
+        {'apikey': 'api-key', 'child_ref': 'child-ref'},
+        ('api-key', ''),
+        {'X-Child-Account-By-CreatorRef': 'child-ref'},
+    ),
+    (
+        {'apikey': 'api-key', 'child_id': 123},
+        ('api-key', ''),
+        {'X-Child-Account-By-Id': 123},
+    ),
+])
+def test_auth_modes_send_expected_auth_and_headers(
+        monkeypatch, kwargs, expected_auth, expected_headers):
+    calls = []
+
+    def fake_get(url, auth, headers, **other_args):
+        calls.append({
+            'url': url,
+            'auth': auth,
+            'headers': headers,
+            'other_args': other_args,
+        })
+        return FakeResponse(200, {'ok': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    result = Auth(url=API_ADDRESS, **kwargs).get('whoami')
+
+    assert result == {'ok': True}
+    assert calls == [{
+        'url': API_ADDRESS + '/whoami',
+        'auth': expected_auth,
+        'headers': expected_headers,
+        'other_args': {},
+    }]
+
+
+def test_post_serializes_fields_without_mutating_headers(monkeypatch):
+    calls = []
+
+    def fake_post(url, auth, headers, **other_args):
+        calls.append({
+            'url': url,
+            'auth': auth,
+            'headers': headers,
+            'other_args': other_args,
+        })
+        return FakeResponse(200, {'created': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.post', fake_post)
+    headers = {'X-Custom': 'value'}
+    fields = {'title': 'Example', 'qty': 2}
+
+    result = Auth(url=API_ADDRESS, apikey=API_KEY).post(
+        '/printjobs',
+        fields=fields,
+        request_headers=headers)
+
+    assert result == {'created': True}
+    assert headers == {'X-Custom': 'value'}
+    assert calls[0]['headers'] == {'X-Custom': 'value'}
+    assert json.loads(calls[0]['other_args']['data']) == fields
+
+
+def test_post_with_no_fields_omits_request_body(monkeypatch):
+    calls = []
+
+    def fake_post(url, auth, headers, **other_args):
+        calls.append(other_args)
+        return FakeResponse(200, {'created': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.post', fake_post)
+
+    Auth(url=API_ADDRESS, apikey=API_KEY).post('printjobs')
+
+    assert calls == [{}]
+
+
+def test_patch_adds_json_content_type_without_mutating_headers(monkeypatch):
+    calls = []
+
+    def fake_patch(url, auth, headers, **other_args):
+        calls.append({'headers': headers, 'other_args': other_args})
+        return FakeResponse(200, {'updated': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.patch', fake_patch)
+    headers = {'X-Custom': 'value'}
+
+    result = Auth(url=API_ADDRESS, clientkey='client-key').patch(
+        'account',
+        fields={'firstname': 'Ada'},
+        request_headers=headers)
+
+    assert result == {'updated': True}
+    assert headers == {'X-Custom': 'value'}
+    assert calls[0]['headers'] == {
+        'X-Custom': 'value',
+        'X-Auth-With-Client-Key': 'API',
+        'Content-Type': 'application/json',
+    }
+
+
+def test_sslcert_is_used_as_verify_path(monkeypatch, tmp_path):
+    cert_path = tmp_path / 'cert.pem'
+    cert_path.write_text('certificate')
+    calls = []
+
+    def fake_delete(url, auth, headers, **other_args):
+        calls.append(other_args)
+        return FakeResponse(200, {'deleted': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.delete', fake_delete)
+
+    Auth(url=API_ADDRESS, apikey=API_KEY, sslcert=str(cert_path)).delete(
+        'printjobs/123')
+
+    assert calls == [{'verify': str(cert_path)}]
+
+
+def test_missing_sslcert_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        Auth(url=API_ADDRESS, apikey=API_KEY, sslcert='/no/such/cert.pem')
+
+
+@pytest.mark.parametrize('status_code,error_type', [
+    (401, Unauthorized),
+    (429, TooManyRequests),
+    (404, ClientError),
+    (500, ServerError),
+])
+def test_request_maps_api_error_status_codes(
+        monkeypatch, status_code, error_type):
+    def fake_get(url, auth, headers, **other_args):
+        return FakeResponse(status_code, {
+            'code': 'ExampleError',
+            'message': 'Something went wrong',
+            'uid': 'error-uid',
+        })
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    with pytest.raises(error_type) as error:
+        Auth(url=API_ADDRESS, apikey=API_KEY).get('whoami')
+
+    assert error.value.status_code == status_code
+    assert error.value.code == 'ExampleError'
+    assert error.value.message == 'Something went wrong'
+    assert error.value.uid == 'error-uid'
+
+
+def test_request_rejects_non_json_response(monkeypatch):
+    def fake_get(url, auth, headers, **other_args):
+        return FakeResponse(200, 'not json', content_type='text/html')
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    with pytest.raises(ValueError, match='Incorrect Content-Type'):
+        Auth(url=API_ADDRESS, apikey=API_KEY).get('whoami')
+
+
+def test_request_accepts_json_content_type_with_charset(monkeypatch):
+    def fake_get(url, auth, headers, **other_args):
+        return FakeResponse(
+            200,
+            {'ok': True},
+            content_type='application/json; charset=utf-8')
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    assert Auth(url=API_ADDRESS, apikey=API_KEY).get('whoami') == {'ok': True}
+
+
+def test_request_raises_for_unexpected_status_code(monkeypatch):
+    def fake_get(url, auth, headers, **other_args):
+        return FakeResponse(302, {'redirect': True})
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    with pytest.raises(Exception, match='status code: 302'):
+        Auth(url=API_ADDRESS, apikey=API_KEY).get('whoami')
+
+
+@pytest.mark.parametrize('request_error,expected_error', [
+    (requests.Timeout('slow'), TimeoutError),
+    (requests.ReadTimeout('read timeout'), TimeoutError),
+    (requests.ConnectionError('offline'), ConnectionError),
+    (requests.RequestException('broken'), RequestError),
+])
+def test_request_rewrites_requests_exceptions(
+        monkeypatch, request_error, expected_error):
+    def fake_get(url, auth, headers, **other_args):
+        raise request_error
+
+    monkeypatch.setattr('printnodeapi.auth.requests.get', fake_get)
+
+    with pytest.raises(expected_error) as error:
+        Auth(url=API_ADDRESS, apikey=API_KEY).get('whoami')
+
+    assert str(error.value) == str(request_error)


### PR DESCRIPTION
## Summary
- prevent `Auth._request` from mutating caller-supplied headers
- accept JSON content types with parameters, such as `application/json; charset=utf-8`
- map `requests` exception subclasses to the intended custom network errors
- add credential-free request-layer tests for auth modes, body serialization, status/error mapping, content types, SSL cert handling, and exception rewriting

## Verification
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `uv run twine check dist/*`

## Compatibility Notes
- Preserves existing public API and request method signatures.
- Header composition keeps auth headers taking precedence over caller-provided headers, matching previous effective behavior without mutating input dictionaries.