### PR TITLE
Expand model and endpoint tests

### DIFF
--- a/printnodeapi/computers.py
+++ b/printnodeapi/computers.py
@@ -160,7 +160,7 @@ class Computers:
             if len(printers) == 0:
                 raise LookupError('printer not found')
             elif len(printers) > 1:
-                printer_ids = ','.join(p.id for p in printers)
+                printer_ids = ','.join(str(p.id) for p in printers)
                 msg = 'multiple printers match destination: {}'.format(
                     printer_ids)
                 raise LookupError(msg)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,170 @@
+import pytest
+
+from printnodeapi.accounts import Accounts
+from printnodeapi.model import ModelFactory
+
+
+class FakeAuth:
+    def __init__(self, get_responses=None):
+        self.get_responses = get_responses or {}
+        self.get_calls = []
+        self.post_calls = []
+        self.patch_calls = []
+        self.delete_calls = []
+
+    def get(self, url, request_headers=None):
+        self.get_calls.append((url, request_headers))
+        return self.get_responses[url]
+
+    def post(self, url, fields=None):
+        self.post_calls.append((url, fields))
+        return 123
+
+    def patch(self, url, fields=None):
+        self.patch_calls.append((url, fields))
+        return 123
+
+    def delete(self, url):
+        self.delete_calls.append(url)
+        return True
+
+
+def make_accounts(get_responses=None):
+    auth = FakeAuth(get_responses)
+    return Accounts(auth, ModelFactory()), auth
+
+
+def client_payload(**overrides):
+    payload = {
+        'id': 10,
+        'enabled': True,
+        'edition': 'stable',
+        'version': '1.2.3',
+        'os': 'windows',
+        'filename': 'printnode.exe',
+        'filesize': 1234,
+        'sha1': 'abc123',
+        'releaseTimestamp': '2026-04-26T00:00:00.000Z',
+        'url': 'https://example.com/printnode.exe',
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_get_clients_lists_all_clients():
+    accounts, auth = make_accounts({
+        '/download/clients/': [client_payload(id=10)],
+    })
+
+    clients = accounts.get_clients()
+
+    assert auth.get_calls == [('/download/clients/', None)]
+    assert clients[0].id == 10
+    assert clients[0].sha_1 == 'abc123'
+
+
+def test_get_clients_fetches_latest_download_for_os():
+    accounts, auth = make_accounts({
+        '/download/client/windows': client_payload(),
+    })
+
+    download = accounts.get_clients(os='windows')
+
+    assert auth.get_calls == [('/download/client/windows', None)]
+    assert download.os == 'windows'
+
+
+def test_modify_client_downloads_requires_bool_enabled():
+    accounts, _auth = make_accounts()
+
+    with pytest.raises(ValueError, match='enabled'):
+        accounts.modify_client_downloads(client_ids=10, enabled='yes')
+
+
+def test_modify_client_downloads_patches_enabled_flag():
+    accounts, auth = make_accounts()
+
+    assert accounts.modify_client_downloads(client_ids=10, enabled=False) == 123
+    assert auth.patch_calls == [('/download/clients/10', {'enabled': False})]
+
+
+def test_create_account_posts_required_and_optional_fields():
+    accounts, auth = make_accounts()
+
+    account_id = accounts.create_account(
+        firstname='Ada',
+        lastname='Lovelace',
+        email='ada@example.com',
+        password='secret',
+        creator_ref='ada-ref',
+        api_keys=['key'],
+        tags={'team': 'ops'},
+    )
+
+    assert account_id == 123
+    assert auth.post_calls == [('/account', {
+        'Account': {
+            'firstname': 'Ada',
+            'lastname': 'Lovelace',
+            'email': 'ada@example.com',
+            'password': 'secret',
+            'creatorRef': 'ada-ref',
+        },
+        'ApiKeys': ['key'],
+        'Tags': {'team': 'ops'},
+    })]
+
+
+def test_modify_account_requires_at_least_one_field():
+    accounts, _auth = make_accounts()
+
+    with pytest.raises(ValueError, match='No fields selected'):
+        accounts.modify_account()
+
+
+def test_modify_account_patches_selected_fields():
+    accounts, auth = make_accounts()
+
+    account_id = accounts.modify_account(firstname='Ada', creator_ref='ada-ref')
+
+    assert account_id == 123
+    assert auth.patch_calls == [('/account', {
+        'firstname': 'Ada',
+        'creatorRef': 'ada-ref',
+    })]
+
+
+def test_tag_and_api_key_helpers_build_expected_paths():
+    accounts, auth = make_accounts({
+        'account/tag/team': 'ops',
+        '/account/apikey/key': {'key': 'key'},
+        '/client/key/uuid?edition=stable&version=1.2.3': 'client-key',
+    })
+
+    assert accounts.get_tag('team') == 'ops'
+    assert accounts.modify_tag('team', 'ops') == 123
+    assert accounts.delete_tag('team') is True
+    assert accounts.get_api_key('key') == {'key': 'key'}
+    assert accounts.create_api_key('key') == 123
+    assert accounts.delete_api_key('key') is True
+    assert accounts.get_clientkey(
+        uuid='uuid',
+        version='1.2.3',
+        edition='stable') == 'client-key'
+
+    assert auth.get_calls == [
+        ('account/tag/team', None),
+        ('/account/apikey/key', None),
+        (
+            '/client/key/uuid?edition=stable&version=1.2.3',
+            {'Content-Type': 'application/json'},
+        ),
+    ]
+    assert auth.post_calls == [
+        ('account/tag/team', 'ops'),
+        ('/account/apikey/key', None),
+    ]
+    assert auth.delete_calls == [
+        'account/tag/team',
+        'account/apikey/key',
+    ]

--- a/tests/test_computers.py
+++ b/tests/test_computers.py
@@ -1,0 +1,227 @@
+import pytest
+
+from printnodeapi.computers import Computers
+from printnodeapi.model import ModelFactory, Printer
+
+from tests.test_model import computer_payload, printer_payload, printjob_payload
+
+
+class FakeAuth:
+    def __init__(self, get_responses=None):
+        self.get_responses = get_responses or {}
+        self.get_calls = []
+        self.post_calls = []
+
+    def get(self, url):
+        self.get_calls.append(url)
+        return self.get_responses[url]
+
+    def post(self, url, fields=None):
+        self.post_calls.append((url, fields))
+        return 900
+
+
+def make_computers(get_responses=None):
+    auth = FakeAuth(get_responses)
+    return Computers(auth, ModelFactory()), auth
+
+
+def test_get_computers_lists_all_with_pagination():
+    computers, auth = make_computers({
+        '/computers?limit=10&after=20&dir=desc': [computer_payload()],
+    })
+
+    result = computers.get_computers(limit=10, after=20, dir='desc')
+
+    assert auth.get_calls == ['/computers?limit=10&after=20&dir=desc']
+    assert [computer.name for computer in result] == ['Office Computer']
+
+
+def test_get_computers_filters_by_name_after_list_query():
+    computers, auth = make_computers({
+        '/computers': [
+            computer_payload(id=100, name='Office Computer'),
+            computer_payload(id=101, name='Warehouse Computer'),
+        ],
+    })
+
+    result = computers.get_computers(computer='Warehouse Computer')
+
+    assert auth.get_calls == ['/computers']
+    assert [computer.id for computer in result] == [101]
+
+
+def test_get_computer_by_id_returns_single_computer():
+    computers, auth = make_computers({
+        '/computers/100': [computer_payload(id=100)],
+    })
+
+    result = computers.get_computers(computer=100)
+
+    assert auth.get_calls == ['/computers/100']
+    assert result.id == 100
+
+
+def test_get_computer_by_id_raises_when_not_found():
+    computers, _auth = make_computers({'/computers/999': []})
+
+    with pytest.raises(LookupError, match='computer not found with ID 999'):
+        computers.get_computers(computer=999)
+
+
+def test_get_printers_for_computer_builds_expected_url():
+    computers, auth = make_computers({
+        '/computers/100/printers?limit=5': [printer_payload()],
+    })
+
+    result = computers.get_printers(computer=100, limit=5)
+
+    assert auth.get_calls == ['/computers/100/printers?limit=5']
+    assert [printer.name for printer in result] == ['Shipping Printer']
+
+
+def test_get_printer_by_id_returns_single_printer():
+    computers, auth = make_computers({
+        '/printers/200': [printer_payload(id=200)],
+    })
+
+    result = computers.get_printers(printer=200)
+
+    assert auth.get_calls == ['/printers/200']
+    assert result.id == 200
+
+
+def test_get_printjobs_lists_all_with_title_filter():
+    computers, auth = make_computers({
+        '/printjobs': [
+            printjob_payload(id=300, title='Packing Slip'),
+            printjob_payload(id=301, title='Return Label'),
+        ],
+    })
+
+    result = computers.get_printjobs(printjob='Return Label')
+
+    assert auth.get_calls == ['/printjobs']
+    assert [printjob.id for printjob in result] == [301]
+
+
+def test_get_printjobs_for_computer_and_named_printer_builds_printer_query():
+    computers, auth = make_computers({
+        '/computers/100/printers': [printer_payload(id=200)],
+        '/printers/200/printjobs?limit=3': [printjob_payload(id=300)],
+    })
+
+    result = computers.get_printjobs(
+        computer=100,
+        printer='Shipping Printer',
+        limit=3)
+
+    assert auth.get_calls == [
+        '/computers/100/printers',
+        '/printers/200/printjobs?limit=3',
+    ]
+    assert [printjob.id for printjob in result] == [300]
+
+
+def test_get_printjob_by_id_returns_single_printjob():
+    computers, auth = make_computers({
+        '/printjobs/300': [printjob_payload(id=300)],
+    })
+
+    result = computers.get_printjobs(printjob=300)
+
+    assert auth.get_calls == ['/printjobs/300']
+    assert result.id == 300
+
+
+def test_get_states_builds_global_and_printjob_specific_paths():
+    computers, auth = make_computers({
+        '/printjobs/states?limit=5': [[{
+            'printJobId': 300,
+            'state': 'new',
+            'message': None,
+            'data': {},
+            'clientVersion': '1.0.0',
+            'createTimestamp': '2026-04-26T00:00:00.000Z',
+            'age': 0,
+        }]],
+        '/printjobs/300/states': [[{
+            'printJobId': 300,
+            'state': 'done',
+            'message': None,
+            'data': {},
+            'clientVersion': '1.0.0',
+            'createTimestamp': '2026-04-26T00:00:01.000Z',
+            'age': 1,
+        }]],
+    })
+
+    global_states = computers.get_states(limit=5)
+    printjob_states = computers.get_states(pjob_set=300)
+
+    assert auth.get_calls == [
+        '/printjobs/states?limit=5',
+        '/printjobs/300/states',
+    ]
+    assert global_states[0][0].state == 'new'
+    assert printjob_states[0][0].state == 'done'
+
+
+def test_submit_printjob_encodes_binary_content_and_posts_job():
+    computers, auth = make_computers({
+        '/printers/200': [printer_payload(id=200)],
+    })
+
+    printjob_id = computers.submit_printjob(
+        printer=200,
+        job_type='pdf',
+        title='Packing Slip',
+        qty=2,
+        options={'paper': 'Letter'},
+        binary=b'PDF')
+
+    assert printjob_id == 900
+    assert auth.post_calls == [('/printjobs', {
+        'printerId': 200,
+        'title': 'Packing Slip',
+        'contentType': 'pdf_base64',
+        'content': 'UERG',
+        'source': 'PythonApiClient',
+        'options': {'paper': 'Letter'},
+        'qty': 2,
+    })]
+
+
+def test_submit_printjob_reports_multiple_matching_printer_ids():
+    computers, _auth = make_computers({
+        '/computers/100/printers': [
+            printer_payload(id=200, name='Shipping Printer'),
+            printer_payload(id=201, name='Shipping Printer'),
+        ],
+    })
+
+    with pytest.raises(LookupError, match='200,201'):
+        computers.submit_printjob(
+            computer=100,
+            printer='Shipping Printer',
+            uri='https://example.com/file.pdf')
+
+
+@pytest.mark.parametrize('kwargs,error', [
+    ({'limit': '10'}, TypeError),
+    ({'after': '20'}, TypeError),
+    ({'dir': 'sideways'}, TypeError),
+])
+def test_pagination_params_validate_inputs(kwargs, error):
+    computers, _auth = make_computers()
+
+    with pytest.raises(error):
+        computers.get_computers(**kwargs)
+
+
+def test_get_printer_id_accepts_printer_model_instance():
+    computers, _auth = make_computers()
+    printer = ModelFactory().create_printer(printer_payload(id=200))
+
+    assert isinstance(printer, Printer)
+    assert computers._get_printer_id(printer) == 200

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,162 @@
+from printnodeapi.model import (
+    Account,
+    Capabilities,
+    Computer,
+    ModelFactory,
+    PrintJob,
+    safe_tuple_populate,
+)
+
+
+def computer_payload(**overrides):
+    payload = {
+        'id': 100,
+        'name': 'Office Computer',
+        'inet': '192.0.2.1',
+        'inet6': '2001:db8::1',
+        'hostname': 'office-host',
+        'version': '1.0.0',
+        'createTimestamp': '2026-04-26T00:00:00.000Z',
+        'state': 'connected',
+        'jre': 'ignored by model',
+        'unexpected': 'ignored',
+    }
+    payload.update(overrides)
+    return payload
+
+
+def printer_payload(**overrides):
+    payload = {
+        'id': 200,
+        'computer': computer_payload(),
+        'name': 'Shipping Printer',
+        'description': 'Thermal label printer',
+        'capabilities': {
+            'bins': [],
+            'collate': True,
+            'copies': 99,
+            'color': False,
+            'dpis': [203],
+            'duplex': False,
+            'extent': [],
+            'medias': [],
+            'nup': [],
+            'papers': [],
+            'printrate': None,
+            'supportsCustomPaperSize': True,
+        },
+        'default': True,
+        'createTimestamp': '2026-04-26T00:00:00.000Z',
+        'state': 'online',
+    }
+    payload.update(overrides)
+    return payload
+
+
+def printjob_payload(**overrides):
+    payload = {
+        'id': 300,
+        'printer': printer_payload(),
+        'title': 'Packing Slip',
+        'contentType': 'pdf_uri',
+        'source': 'PythonApiClient',
+        'expireAt': None,
+        'createTimestamp': '2026-04-26T00:00:00.000Z',
+        'state': 'new',
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_safe_tuple_populate_ignores_extra_fields_and_defaults_missing_fields():
+    fields = {
+        'id': 123,
+        'firstname': 'Ada',
+        'lastname': 'Lovelace',
+        'email': 'ada@example.com',
+        'extra': 'ignored',
+    }
+
+    account = safe_tuple_populate(Account, fields, defaults={
+        'can_create_sub_accounts': False,
+        'creator_email': None,
+        'creator_ref': None,
+        'child_accounts': [],
+        'credits': 0,
+        'num_computers': 0,
+        'total_prints': 0,
+        'versions': [],
+        'connected': False,
+        'tags': {},
+        'state': 'active',
+        'api_keys': [],
+        'permissions': [],
+    })
+
+    assert account.firstname == 'Ada'
+    assert account.can_create_sub_accounts is False
+    assert not hasattr(account, 'extra')
+
+
+def test_create_account_defaults_optional_collections():
+    account = ModelFactory().create_account({
+        'id': 123,
+        'firstname': 'Ada',
+        'lastname': 'Lovelace',
+        'email': 'ada@example.com',
+        'canCreateSubAccounts': False,
+        'creatorEmail': None,
+        'creatorRef': None,
+        'childAccounts': [],
+        'credits': 0,
+        'numComputers': 0,
+        'totalPrints': 0,
+        'versions': [],
+        'connected': False,
+        'tags': {},
+        'state': 'active',
+    })
+
+    assert account.api_keys == []
+    assert account.permissions == []
+
+
+def test_create_computer_maps_camel_case_and_ignores_jre():
+    computer = ModelFactory().create_computer(computer_payload())
+
+    assert isinstance(computer, Computer)
+    assert computer.create_timestamp == '2026-04-26T00:00:00.000Z'
+    assert computer.inet6 == '2001:db8::1'
+    assert not hasattr(computer, 'jre')
+
+
+def test_create_printer_builds_nested_computer_and_capabilities():
+    printer = ModelFactory().create_printer(printer_payload())
+
+    assert printer.computer.name == 'Office Computer'
+    assert isinstance(printer.capabilities, Capabilities)
+    assert printer.capabilities.supports_custom_paper_size is True
+
+
+def test_create_printjob_defaults_optional_fields():
+    printjob = ModelFactory().create_printjob(printjob_payload())
+
+    assert isinstance(printjob, PrintJob)
+    assert printjob.content is None
+    assert printjob.pages is None
+    assert printjob.qty == 1
+    assert printjob.options == {}
+
+
+def test_create_printjob_preserves_server_supplied_optional_fields():
+    printjob = ModelFactory().create_printjob(printjob_payload(
+        content='https://example.com/file.pdf',
+        pages=4,
+        qty=2,
+        options={'paper': 'Letter'},
+    ))
+
+    assert printjob.content == 'https://example.com/file.pdf'
+    assert printjob.pages == 4
+    assert printjob.qty == 2
+    assert printjob.options == {'paper': 'Letter'}


### PR DESCRIPTION
## Summary
- add credential-free tests for model construction and normalization
- add endpoint/path tests for Computers and Accounts helpers
- cover printjob submission request payloads, state lookup paths, pagination validation, and account/client helper payloads
- fix multiple matching printer error reporting so integer printer IDs are joined safely

## Verification
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `uv run twine check dist/*`

## Compatibility Notes
- Preserves public API.
- The only behavior change is replacing an accidental `TypeError` with the intended `LookupError` when multiple printers match a submit destination.