### PR TITLE
Add release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Package repository to publish to"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.repository }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --locked --python 3.14
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build artifacts
+        run: uv build
+
+      - name: Check artifact metadata
+        run: uv run twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-distributions
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to ${{ inputs.repository }}
+    runs-on: ubuntu-latest
+    needs: build
+    environment: ${{ inputs.repository }}
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: release-distributions
+          path: dist
+
+      - name: Publish to TestPyPI
+        if: inputs.repository == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@v1.9.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: inputs.repository == 'pypi'
+        uses: pypa/gh-action-pypi-publish@v1.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 - Added contribution, security, issue, and pull request guidance.
 - Added modern Python project metadata in `pyproject.toml`.
 - Added an initial `uv` development workflow.
+- Added release process documentation and a manual trusted-publishing workflow scaffold.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ uv build
 uv run twine check dist/*
 ```
 
+### Releases
+
+Release publishing is not enabled for general use yet. See [RELEASE.md](RELEASE.md) for the release process, current package-name blocker, and TestPyPI/PyPI workflow requirements.
+
 ### Getting Started
 
 The default constructor for the Library is a Gateway, which is constructed with at minimum of one key-word argument, that being an api-key.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,81 @@
+# Release Process
+
+This fork is being prepared for maintained releases, but publishing is blocked until the distribution-name and PyPI ownership decision is complete.
+
+## Current Release Blocker
+
+The historical PyPI distribution name is `PrintNodeApi`. Do not publish until one of these paths is confirmed:
+
+- PyPI maintainer access is granted for `PrintNodeApi`; or
+- the fork chooses and tests a distinct distribution name, such as `printnode-api`, while preserving the `printnodeapi` import package.
+
+## Versioning
+
+Use semantic versioning once maintained releases begin.
+
+- Patch releases: bug fixes, packaging fixes, documentation corrections, and compatibility fixes that preserve public API behavior.
+- Minor releases: new PrintNode API coverage, new optional features, or deprecations that preserve compatibility.
+- Major releases: breaking API changes, import-path changes, or removal of documented compatibility.
+
+Keep the package version in `pyproject.toml` and the top `CHANGELOG.md` release section in sync.
+
+## Pre-Release Checklist
+
+1. Confirm the package name and PyPI/TestPyPI trusted publisher configuration.
+2. Confirm `main` is green in CI.
+3. Create a release branch from `main`.
+4. Update `pyproject.toml` with the release version.
+5. Update `CHANGELOG.md` by moving relevant `Unreleased` entries under the release version and date.
+6. Run local verification:
+
+```sh
+uv sync --locked
+uv run pytest
+rm -rf dist && uv build
+uv run twine check dist/*
+```
+
+7. Open a release PR and wait for required CI checks.
+8. Merge the release PR.
+9. Create a signed Git tag if signing is configured; otherwise create an annotated tag:
+
+```sh
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+10. Create a GitHub Release from the tag using the changelog section as release notes.
+11. Run the manual `Publish` workflow for TestPyPI first.
+12. Install from TestPyPI in a clean environment and smoke-test imports.
+13. Run the manual `Publish` workflow for PyPI only after TestPyPI passes.
+
+## TestPyPI Smoke Test
+
+Use a clean environment and the chosen distribution name:
+
+```sh
+uv venv /tmp/printnodeapi-release-smoke
+source /tmp/printnodeapi-release-smoke/bin/activate
+uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ <distribution-name>
+python -c "from printnodeapi import Gateway; print(Gateway.__name__)"
+deactivate
+```
+
+## GitHub Environments
+
+Configure two GitHub environments before publishing:
+
+- `testpypi`
+- `pypi`
+
+Both environments should require manual approval. Configure each environment as a trusted publisher in the corresponding PyPI project before running the workflow.
+
+The `Publish` workflow uses GitHub OpenID Connect through `id-token: write`; do not add PyPI API tokens unless trusted publishing is unavailable.
+
+## Rollback
+
+Published packages cannot be overwritten. If a bad release is published:
+
+- yank the release on PyPI if appropriate;
+- document the issue in `CHANGELOG.md` and GitHub Releases;
+- publish a new patch release with the fix.


### PR DESCRIPTION
## Summary
- add `RELEASE.md` with versioning, release checklist, TestPyPI smoke test, rollback notes, and current package-name blocker
- add a manual `Publish` workflow scaffold using trusted publishing and GitHub environments
- link release docs from the README and note the addition in the changelog

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml')"`\n- `actionlint .github/workflows/publish.yml .github/workflows/ci.yml`\n- `uv run pytest`\n- `rm -rf dist && uv build`\n- `uv run twine check dist/*`\n\n## Notes\n- This does not publish anything. The workflow is manual and still requires GitHub environment/trusted publisher setup.\n- Publishing remains blocked until the `PrintNodeApi` access vs distinct distribution name decision is resolved.