### PR TITLE
Adopt printnode-api distribution name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 
 ### Changed
 
+- Selected `printnode-api` as the maintained distribution name while preserving the `printnodeapi` import package.
 - Documented the plan to migrate the default branch from `master` to `main`.
 - Migrated the default branch from `master` to `main`.
 - Replaced legacy `setup.py` packaging with `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## **PrintNode API Client Python Library**
 
 > [!NOTE]
-> This repository is being prepared as a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The current stewardship plan is to preserve the existing `printnodeapi` import path, use `main` as the default branch, modernize packaging with `pyproject.toml` and `uv`, and release only after CI, tests, and package publishing are in good shape.
+> This repository is a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The maintained distribution name is `printnode-api`; the Python import path remains `printnodeapi` for compatibility.
 
 This is a Python library to interact with PrintNode's remote printing API. This client allows you to access the API's functions for quick use in Python scripts.
 
@@ -12,6 +12,18 @@ This is a Python library to interact with PrintNode's remote printing API. This 
 * future
 
 ### Installation
+
+After the first maintained release is published, install the package with:
+
+```sh
+uv add printnode-api
+```
+
+or:
+
+```sh
+python -m pip install printnode-api
+```
 
 Install from source with `uv`:
 
@@ -25,7 +37,7 @@ For editable development installs, use:
 uv pip install -e .
 ```
 
-This project is being prepared for a maintained package release. Until then, prefer installing from a reviewed Git tag or branch rather than relying on an unpublished local build.
+Until the first maintained release is published, prefer installing from a reviewed Git tag or branch rather than relying on an unpublished local build.
 
 ### Development
 
@@ -45,7 +57,7 @@ uv run twine check dist/*
 
 ### Releases
 
-Release publishing is not enabled for general use yet. See [RELEASE.md](RELEASE.md) for the release process, current package-name blocker, and TestPyPI/PyPI workflow requirements.
+Release publishing is not enabled for general use yet. See [RELEASE.md](RELEASE.md) for the release process and TestPyPI/PyPI workflow requirements.
 
 ### Getting Started
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,12 @@
 # Release Process
 
-This fork is being prepared for maintained releases, but publishing is blocked until the distribution-name and PyPI ownership decision is complete.
+This fork is being prepared for maintained releases under the `printnode-api` distribution name. The Python import package remains `printnodeapi` for compatibility.
 
-## Current Release Blocker
+## Package Name
 
-The historical PyPI distribution name is `PrintNodeApi`. Do not publish until one of these paths is confirmed:
+The historical PyPI distribution name is `PrintNodeApi`, but upstream has not responded to maintainer handoff requests. This community-maintained fork will publish as `printnode-api` instead.
 
-- PyPI maintainer access is granted for `PrintNodeApi`; or
-- the fork chooses and tests a distinct distribution name, such as `printnode-api`, while preserving the `printnodeapi` import package.
+Before the first release, verify that `printnode-api` is still available on both PyPI and TestPyPI, then configure trusted publishing for that name.
 
 ## Versioning
 
@@ -21,7 +20,7 @@ Keep the package version in `pyproject.toml` and the top `CHANGELOG.md` release 
 
 ## Pre-Release Checklist
 
-1. Confirm the package name and PyPI/TestPyPI trusted publisher configuration.
+1. Confirm `printnode-api` is still available and PyPI/TestPyPI trusted publisher configuration is ready.
 2. Confirm `main` is green in CI.
 3. Create a release branch from `main`.
 4. Update `pyproject.toml` with the release version.
@@ -51,12 +50,12 @@ git push origin vX.Y.Z
 
 ## TestPyPI Smoke Test
 
-Use a clean environment and the chosen distribution name:
+Use a clean environment:
 
 ```sh
 uv venv /tmp/printnodeapi-release-smoke
 source /tmp/printnodeapi-release-smoke/bin/activate
-uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ <distribution-name>
+uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ printnode-api
 python -c "from printnodeapi import Gateway; print(Gateway.__name__)"
 deactivate
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "PrintNodeApi"
+name = "printnode-api"
 version = "0.2.0"
-description = "Python client for PrintNode's API"
+description = "Community-maintained Python client for PrintNode's API"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 ]
 
 [[package]]
-name = "printnodeapi"
+name = "printnode-api"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- change the Python distribution name from `PrintNodeApi` to `printnode-api`
- preserve the `printnodeapi` import package
- update README and release docs now that the community-fork package-name decision is made
- regenerate `uv.lock` for the new project name

## Verification
- verified `printnode-api` returns 404 on PyPI and TestPyPI before this change
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `ls -1 dist`
- `uv run twine check dist/*`
- import/package metadata smoke test: `metadata('printnode-api')` and `from printnodeapi import Gateway`

## Compatibility Notes
- Installation name changes to `printnode-api` for maintained fork releases.
- Runtime import path remains `printnodeapi` for compatibility.