### PR TITLE
Add printnode_api import namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 - Added modern Python project metadata in `pyproject.toml`.
 - Added an initial `uv` development workflow.
 - Added release process documentation and a manual trusted-publishing workflow scaffold.
+- Added `printnode_api` as the preferred import namespace while keeping `printnodeapi` for compatibility.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## **PrintNode API Client Python Library**
 
 > [!NOTE]
-> This repository is a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The maintained distribution name is `printnode-api`; the Python import path remains `printnodeapi` for compatibility.
+> This repository is a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The maintained distribution name is `printnode-api`; new code should import `printnode_api`, and the historical `printnodeapi` import path remains supported for compatibility.
 
 This is a Python library to interact with PrintNode's remote printing API. This client allows you to access the API's functions for quick use in Python scripts.
 
@@ -16,13 +16,13 @@ This is a Python library to interact with PrintNode's remote printing API. This 
 After the first maintained release is published, install the package with:
 
 ```sh
-uv add printnode-api
+uv add printnode_api
 ```
 
 or:
 
 ```sh
-python -m pip install printnode-api
+python -m pip install printnode_api
 ```
 
 Install from source with `uv`:
@@ -64,8 +64,14 @@ Release publishing is not enabled for general use yet. See [RELEASE.md](RELEASE.
 The default constructor for the Library is a Gateway, which is constructed with at minimum of one key-word argument, that being an api-key.
 
 ```python
-from printnodeapi.Gateway import Gateway
+from printnode_api import Gateway
 my_account_gateway = Gateway(apikey='my_api_key')
+```
+
+The historical import path remains supported:
+
+```python
+from printnodeapi import Gateway
 ```
 
 After creating a Gateway, you can access any requests as such:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,12 @@
 # Release Process
 
-This fork is being prepared for maintained releases under the `printnode-api` distribution name. The Python import package remains `printnodeapi` for compatibility.
+This fork is being prepared for maintained releases under the `printnode-api` distribution name. New code should import `printnode_api`, and the historical `printnodeapi` import package remains supported for compatibility.
 
 ## Package Name
 
 The historical PyPI distribution name is `PrintNodeApi`, but upstream has not responded to maintainer handoff requests. This community-maintained fork will publish as `printnode-api` instead.
+
+PyPI normalizes `printnode-api` and `printnode_api` as the same project name. Prefer documenting `uv add printnode_api` and `python -m pip install printnode_api` so the install command visually matches the preferred `printnode_api` import namespace.
 
 Before the first release, verify that `printnode-api` is still available on both PyPI and TestPyPI, then configure trusted publishing for that name.
 
@@ -55,8 +57,8 @@ Use a clean environment:
 ```sh
 uv venv /tmp/printnodeapi-release-smoke
 source /tmp/printnodeapi-release-smoke/bin/activate
-uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ printnode-api
-python -c "from printnodeapi import Gateway; print(Gateway.__name__)"
+uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ printnode_api
+python -c "from printnode_api import Gateway; from printnodeapi import Gateway as LegacyGateway; assert Gateway is LegacyGateway; print(Gateway.__name__)"
 deactivate
 ```
 

--- a/printnode_api/__init__.py
+++ b/printnode_api/__init__.py
@@ -1,0 +1,8 @@
+"""Preferred import namespace for the community-maintained PrintNode client.
+
+The historical import package is ``printnodeapi``. It remains supported for
+compatibility, while new code may import from ``printnode_api`` to match the
+maintained distribution name more closely.
+"""
+
+from printnodeapi import *  # noqa: F401,F403

--- a/printnode_api/accounts.py
+++ b/printnode_api/accounts.py
@@ -1,0 +1,1 @@
+from printnodeapi.accounts import *  # noqa: F401,F403

--- a/printnode_api/auth.py
+++ b/printnode_api/auth.py
@@ -1,0 +1,1 @@
+from printnodeapi.auth import *  # noqa: F401,F403

--- a/printnode_api/computers.py
+++ b/printnode_api/computers.py
@@ -1,0 +1,1 @@
+from printnodeapi.computers import *  # noqa: F401,F403

--- a/printnode_api/gateway.py
+++ b/printnode_api/gateway.py
@@ -1,0 +1,1 @@
+from printnodeapi.gateway import *  # noqa: F401,F403

--- a/printnode_api/model.py
+++ b/printnode_api/model.py
@@ -1,0 +1,1 @@
+from printnodeapi.model import *  # noqa: F401,F403

--- a/printnode_api/util.py
+++ b/printnode_api/util.py
@@ -1,0 +1,1 @@
+from printnodeapi.util import *  # noqa: F401,F403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["printnodeapi"]
+packages = ["printnodeapi", "printnode_api"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,22 @@
+def test_preferred_and_legacy_gateway_imports_match():
+    from printnode_api import Gateway
+    from printnode_api.gateway import Gateway as GatewayFromPreferredModule
+    from printnodeapi import Gateway as LegacyGateway
+    from printnodeapi.gateway import Gateway as GatewayFromLegacyModule
+
+    assert Gateway is GatewayFromPreferredModule
+    assert Gateway is LegacyGateway
+    assert Gateway is GatewayFromLegacyModule
+
+
+def test_preferred_submodules_reexport_legacy_objects():
+    from printnode_api.auth import Unauthorized
+    from printnode_api.model import ModelFactory
+    from printnode_api.util import camel_to_underscore
+    from printnodeapi.auth import Unauthorized as LegacyUnauthorized
+    from printnodeapi.model import ModelFactory as LegacyModelFactory
+    from printnodeapi.util import camel_to_underscore as legacy_camel_to_underscore
+
+    assert Unauthorized is LegacyUnauthorized
+    assert ModelFactory is LegacyModelFactory
+    assert camel_to_underscore is legacy_camel_to_underscore


### PR DESCRIPTION
## Summary
- add `printnode_api` as the preferred import namespace
- keep `printnodeapi` as the compatibility implementation package
- package both namespaces in the wheel
- update README and release docs to document `printnode_api` first
- add import smoke tests for preferred and legacy namespaces

## Verification
- `uv lock`
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `uv run twine check dist/*`
- wheel content check for both `printnode_api` and `printnodeapi`

## Compatibility Notes
- New code can use `from printnode_api import Gateway`.
- Existing `from printnodeapi import Gateway` imports continue to work.