### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 
 ## Unreleased
 
+- Nothing yet.
+
+## 0.3.0 - 2026-04-26
+
 ### Added
 
 - Added repository governance documentation for community maintenance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "printnode-api"
-version = "0.2.0"
+version = "0.3.0"
 description = "Community-maintained Python client for PrintNode's API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -471,7 +471,7 @@ wheels = [
 
 [[package]]
 name = "printnode-api"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "future" },


### PR DESCRIPTION
## Summary
- bump `printnode-api` to version `0.3.0`
- move changelog entries from `Unreleased` into `0.3.0 - 2026-04-26`
- regenerate `uv.lock` for the release version

## Verification
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `ls -1 dist`
- `uv run twine check dist/*`
- metadata/import smoke test for `printnode-api==0.3.0`, `printnode_api`, and `printnodeapi`

## Release Notes
First maintained community release of the PrintNode Python API client under the `printnode-api` distribution name. Adds modern packaging, uv workflow, CI, branch protection, credential-free tests, release workflow scaffolding, and the preferred `printnode_api` import namespace while preserving `printnodeapi` compatibility.

## Publish Status
Do not publish until TestPyPI/PyPI credentials or trusted publishers are configured for `printnode-api`.