### PR TITLE
Align project metadata with printnode_community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 
 ### Changed
 
-- Selected `printnode-community` as the maintained distribution name.
+- Selected `printnode_community` as the maintained project, distribution, and import name.
 - Documented the plan to migrate the default branch from `master` to `main`.
 - Migrated the default branch from `master` to `main`.
 - Replaced legacy `setup.py` packaging with `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## **PrintNode API Client Python Library**
 
 > [!NOTE]
-> This repository is a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The maintained distribution name is `printnode-community`; the import package is `printnode_community`.
+> This repository is a community-maintained fork of the PrintNode Python API client. It is not an official PrintNode release unless PrintNode explicitly confirms maintainership or transfer. The maintained project name is `printnode_community`.
 
 This is a Python library to interact with PrintNode's remote printing API. This client allows you to access the API's functions for quick use in Python scripts.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,14 @@
 # Release Process
 
-This fork is being prepared for maintained releases under the `printnode-community` distribution name. The import package is `printnode_community`.
+This fork is being prepared for maintained releases under the `printnode_community` project name.
 
 ## Package Name
 
-The historical PyPI distribution name is `PrintNodeApi`, but upstream has not responded to maintainer handoff requests. This community-maintained fork will publish as `printnode-community` instead.
+The historical PyPI distribution name is `PrintNodeApi`, but upstream has not responded to maintainer handoff requests. This community-maintained fork will publish as `printnode_community` instead.
 
-PyPI normalizes `printnode-community` and `printnode_community` as the same project name. Prefer documenting `uv add printnode_community` and `python -m pip install printnode_community` so the install command visually matches the `printnode_community` import namespace.
+PyPI normalizes `printnode-community` and `printnode_community` as the same project name. Prefer documenting `uv add printnode_community` and `python -m pip install printnode_community` so the install command visually matches the import namespace.
 
-Before the first release, verify that `printnode-community` is still available on both PyPI and TestPyPI, then configure trusted publishing for that name.
+Before the first release, verify that `printnode_community` is still available on both PyPI and TestPyPI, then configure trusted publishing for that name.
 
 ## Versioning
 
@@ -22,7 +22,7 @@ Keep the package version in `pyproject.toml` and the top `CHANGELOG.md` release 
 
 ## Pre-Release Checklist
 
-1. Confirm `printnode-community` is still available and PyPI/TestPyPI trusted publisher configuration is ready.
+1. Confirm `printnode_community` is still available and PyPI/TestPyPI trusted publisher configuration is ready.
 2. Confirm `main` is green in CI.
 3. Create a release branch from `main`.
 4. Update `pyproject.toml` with the release version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "printnode-community"
+name = "printnode_community"
 version = "0.3.0"
 description = "Community-maintained Python client for PrintNode's API"
 readme = "README.md"
@@ -37,9 +37,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/cbusillo/PrintNode-Python"
-Repository = "https://github.com/cbusillo/PrintNode-Python"
-Issues = "https://github.com/cbusillo/PrintNode-Python/issues"
+Homepage = "https://github.com/cbusillo/printnode_community"
+Repository = "https://github.com/cbusillo/printnode_community"
+Issues = "https://github.com/cbusillo/printnode_community/issues"
 "Upstream Repository" = "https://github.com/PrintNode/PrintNode-Python"
 "PrintNode API Documentation" = "https://www.printnode.com/en/docs/api/curl"
 


### PR DESCRIPTION
## Summary
- use `printnode_community` as the Python project metadata name
- update project URLs for the planned GitHub repository rename
- update README, release docs, and changelog wording so project/distribution/import naming is consistent

## Verification
- `uv lock`
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `uv run twine check dist/*`
- metadata smoke test for `printnode_community==0.3.0`

## Follow-up
After merge, rename the GitHub repository and local folder to `printnode_community`, then recreate the unpublished `v0.3.0` release/tag at the new final commit.