### PR TITLE
Require release tags for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Require release tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Publish must be run from a release tag, not ${GITHUB_REF_TYPE}: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          case "${GITHUB_REF_NAME}" in
+            v*) ;;
+            *)
+              echo "Publish tag must start with 'v': ${GITHUB_REF_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -41,6 +55,15 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --locked --python 3.14
+
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${PACKAGE_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "Package version ${PACKAGE_VERSION} does not match tag ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
 
       - name: Run tests
         run: uv run pytest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,9 +46,9 @@ git push origin vX.Y.Z
 ```
 
 10. Create a GitHub Release from the tag using the changelog section as release notes.
-11. Run the manual `Publish` workflow for TestPyPI first.
+11. Run the manual `Publish` workflow from the release tag for TestPyPI first.
 12. Install from TestPyPI in a clean environment and smoke-test imports.
-13. Run the manual `Publish` workflow for PyPI only after TestPyPI passes.
+13. Run the manual `Publish` workflow from the release tag for PyPI only after TestPyPI passes.
 
 ## TestPyPI Smoke Test
 


### PR DESCRIPTION
## Summary
- require the manual Publish workflow to run from a `v*` tag
- verify the package version in `pyproject.toml` matches the selected release tag
- update release docs to say the publish workflow should be run from the release tag

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml')"`\n- `actionlint .github/workflows/publish.yml .github/workflows/ci.yml`\n- `uv run pytest`\n- `rm -rf dist && uv build`\n- `uv run twine check dist/*`\n\n## Release Note\nAfter this merges, recreate the unpublished `v0.3.0` tag/release at the merge commit before running TestPyPI/PyPI publishing.