### PR TITLE
Document TestPyPI as optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This repository is maintained as a careful, community-oriented Python client for
 
 - Do not publish releases from unreviewed local state.
 - Build and validate distributions before release.
-- Use TestPyPI before first publishing under a new distribution name.
+- Prefer TestPyPI before first publishing under a new distribution name, but allow skipping it when CI, build metadata checks, and release-tag guards are sufficient.
 - Run the manual `Publish` workflow from a `v*` release tag only.
 - Keep the `testpypi` environment unblocked by manual review.
 - Keep the `pypi` environment protected by maintainer approval.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,13 +47,14 @@ git push origin vX.Y.Z
 ```
 
 10. Create a GitHub Release from the tag using the changelog section as release notes.
-11. Run the manual `Publish` workflow from the release tag for TestPyPI first.
-12. Install from TestPyPI in a clean environment and smoke-test imports.
-13. Run the manual `Publish` workflow from the release tag for PyPI only after TestPyPI passes.
+11. Optionally run the manual `Publish` workflow from the release tag for TestPyPI.
+12. If TestPyPI is used, install from TestPyPI in a clean environment and smoke-test imports.
+13. Run the manual `Publish` workflow from the release tag for PyPI.
 
-## TestPyPI Smoke Test
+## Optional TestPyPI Smoke Test
 
-Use a clean environment:
+TestPyPI is a useful publishing dry run, but it is not required for every
+release. Use a clean environment when testing a TestPyPI upload:
 
 ```sh
 uv venv /tmp/printnode_community-release-smoke


### PR DESCRIPTION
## Summary
- document TestPyPI as an optional dry run instead of a mandatory release gate
- keep production PyPI publishing guarded by the release-tag workflow and `pypi` environment approval

## Verification
- `git diff --check`
- `uv run pytest`
- `rm -rf dist && uv build`
- `uv run twine check dist/*`