### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,10 +96,10 @@ jobs:
 
       - name: Publish to TestPyPI
         if: inputs.repository == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
         if: inputs.repository == 'pypi'
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ This repository is maintained as a careful, community-oriented Python client for
 - Prefer TestPyPI before first publishing under a new distribution name, but allow skipping it when CI, build metadata checks, and release-tag guards are sufficient.
 - Run the manual `Publish` workflow from a `v*` release tag only.
 - Keep the `testpypi` environment unblocked by manual review.
-- Keep the `pypi` environment protected by maintainer approval.
+- Do not require GitHub environment review for `pypi`; treat release PR merge,
+  tag creation, and manual workflow dispatch as the publish approval path.
 - Trusted publishers must match project `printnode_community`, owner `cbusillo`, repository `printnode_community`, workflow `publish.yml`, and environment `testpypi` or `pypi`.
 - Update `CHANGELOG.md` for user-visible changes.
 - Keep release notes clear about whether this is an official PrintNode release or a community-maintained fork.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,7 +69,9 @@ deactivate
 Configure two GitHub environments before publishing:
 
 - `testpypi`: no required reviewer, so TestPyPI dry runs do not pause.
-- `pypi`: require maintainer approval before production publishing.
+- `pypi`: no GitHub environment reviewer. Production approval happens by
+  merging the release PR, creating the release tag, and manually dispatching
+  the publish workflow from that tag.
 
 Configure each environment as a trusted publisher in the corresponding PyPI
 project before running the workflow. TestPyPI and PyPI are separate services;


### PR DESCRIPTION
## Summary
- update PyPI publish action to `pypa/gh-action-pypi-publish@release/v1` so current package metadata is accepted
- document that PyPI publish approval happens via release PR merge, tag creation, and manual workflow dispatch rather than a GitHub environment review gate
- update agent release notes accordingly

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml')"`\n- `actionlint .github/workflows/publish.yml .github/workflows/ci.yml`\n- `uv run pytest`\n- `rm -rf dist && uv build`\n- `uv run twine check dist/*`\n\n## Notes\nThe previous PyPI publish run failed because `pypa/gh-action-pypi-publish@v1.9.0` rejected the wheel metadata even though local `twine check` passed.