### PR TITLE
Document empty repo workflow metadata

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -12,5 +12,7 @@
   "cleanup": {
     "deleteMergedLocalBranches": true,
     "removeMergedCleanWorktrees": true
-  }
+  },
+  "relatedRepos": [],
+  "validatedThrough": []
 }


### PR DESCRIPTION
## Summary
- make empty related repository metadata explicit in the repo workflow config
- avoid future workflow sessions needing to infer whether related repos or validation repos exist

## Verification
- git diff --check
- JSON parse validation from editor tooling