### PR TITLE
Harden optional model field handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format follows the spirit of Keep a Changelog, and this project intends to u
 
 - Added repository workflow defaults for future GitHub workflow sessions.
 - Updated post-release documentation now that `0.3.0` is published.
+- Hardened model factory handling for missing or null optional nested PrintNode
+  response fields.
 
 ## 0.3.0 - 2026-04-26
 

--- a/printnode_community/model.py
+++ b/printnode_community/model.py
@@ -62,7 +62,7 @@ class ModelFactory:
 
     def create_computer(self, computer_dict):
         fields = self._underscore_keys(computer_dict)
-        del fields['jre']
+        fields.pop('jre', None)
         self._rename_field(fields, 'inet_6', 'inet6')
         return safe_tuple_populate(Computer, fields)
 
@@ -71,10 +71,9 @@ class ModelFactory:
 
     def create_printer(self, printer_dict):
         fields = self._underscore_keys(printer_dict)
-        fields['computer'] = self.create_computer(fields['computer'])
-        if fields['capabilities']:
-            fields['capabilities'] = self.create_capabilities(
-                fields['capabilities'])
+        self._create_nested_model(fields, 'computer', self.create_computer)
+        self._create_nested_model(
+            fields, 'capabilities', self.create_capabilities)
         return safe_tuple_populate(Printer, fields)
 
     def create_capabilities(self, capabilities_dict):
@@ -86,7 +85,7 @@ class ModelFactory:
 
     def create_printjob(self, printjob_dict):
         fields = self._underscore_keys(printjob_dict)
-        fields['printer'] = self.create_printer(fields['printer'])
+        self._create_nested_model(fields, 'printer', self.create_printer)
         fields.setdefault('content', None)
         fields.setdefault('pages', None)
         fields.setdefault('qty', 1)
@@ -109,9 +108,15 @@ class ModelFactory:
             for k, v in input_dict.items()}
 
     def _rename_field(self, obj_dict, old_name, new_name):
+        if old_name not in obj_dict:
+            return
         assert new_name not in obj_dict
         obj_dict[new_name] = obj_dict[old_name]
         del obj_dict[old_name]
+
+    def _create_nested_model(self, fields, field_name, factory):
+        if field_name in fields and fields[field_name] is not None:
+            fields[field_name] = factory(fields[field_name])
 
     def _map(self, f, iter):
         return list(map(f, iter))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -130,12 +130,44 @@ def test_create_computer_maps_camel_case_and_ignores_jre():
     assert not hasattr(computer, 'jre')
 
 
+def test_create_computer_defaults_missing_optional_network_fields():
+    payload = computer_payload()
+    del payload['jre']
+    del payload['inet6']
+
+    computer = ModelFactory().create_computer(payload)
+
+    assert isinstance(computer, Computer)
+    assert computer.inet6 is None
+
+
 def test_create_printer_builds_nested_computer_and_capabilities():
     printer = ModelFactory().create_printer(printer_payload())
 
     assert printer.computer.name == 'Office Computer'
     assert isinstance(printer.capabilities, Capabilities)
     assert printer.capabilities.supports_custom_paper_size is True
+
+
+def test_create_printer_defaults_missing_optional_nested_fields():
+    payload = printer_payload()
+    del payload['computer']
+    del payload['capabilities']
+
+    printer = ModelFactory().create_printer(payload)
+
+    assert printer.computer is None
+    assert printer.capabilities is None
+
+
+def test_create_printer_preserves_null_nested_fields():
+    printer = ModelFactory().create_printer(printer_payload(
+        computer=None,
+        capabilities=None,
+    ))
+
+    assert printer.computer is None
+    assert printer.capabilities is None
 
 
 def test_create_printjob_defaults_optional_fields():
@@ -146,6 +178,15 @@ def test_create_printjob_defaults_optional_fields():
     assert printjob.pages is None
     assert printjob.qty == 1
     assert printjob.options == {}
+
+
+def test_create_printjob_defaults_missing_printer():
+    payload = printjob_payload()
+    del payload['printer']
+
+    printjob = ModelFactory().create_printjob(payload)
+
+    assert printjob.printer is None
 
 
 def test_create_printjob_preserves_server_supplied_optional_fields():


### PR DESCRIPTION
## Summary
- tolerate missing `jre` / `inet6` values when building computer models
- tolerate missing or null nested printer `computer` and `capabilities` values
- tolerate missing nested print job `printer` data
- add credential-free regression coverage for optional model values

Closes #21

## Verification
- uv run pytest tests/test_model.py
- uv run pytest
- uv build
- uv run twine check dist/*

## Notes
- This PR and #22 both update `CHANGELOG.md` under `Unreleased`; whichever merges second may need a small changelog conflict cleanup.