### PR TITLE
fix(release): create GitHub notes after PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,8 +86,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: ${{ inputs.repository }}
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
       - name: Download artifacts
         uses: actions/download-artifact@v8.0.1
         with:
@@ -103,3 +109,20 @@ jobs:
       - name: Publish to PyPI
         if: inputs.repository == 'pypi'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release notes
+        if: inputs.repository == 'pypi'
+        run: |
+          scripts/extract-changelog-release-notes.sh \
+            --version "${GITHUB_REF_NAME}" \
+            --output release-notes.md
+
+      - name: Create GitHub release
+        if: inputs.repository == 'pypi'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release-notes.md \
+            dist/*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,10 +46,9 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-10. Create a GitHub Release from the tag using the changelog section as release notes.
-11. Optionally run the manual `Publish` workflow from the release tag for TestPyPI.
-12. If TestPyPI is used, install from TestPyPI in a clean environment and smoke-test imports.
-13. Run the manual `Publish` workflow from the release tag for PyPI.
+10. Optionally run the manual `Publish` workflow from the release tag for TestPyPI.
+11. If TestPyPI is used, install from TestPyPI in a clean environment and smoke-test imports.
+12. Run the manual `Publish` workflow from the release tag for PyPI. The workflow creates the GitHub Release from the matching `CHANGELOG.md` section after the PyPI upload succeeds.
 
 ## Optional TestPyPI Smoke Test
 

--- a/scripts/extract-changelog-release-notes.sh
+++ b/scripts/extract-changelog-release-notes.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/extract-changelog-release-notes.sh --version VERSION --output FILE
+
+Extracts the matching CHANGELOG.md section for a GitHub Release body.
+USAGE
+}
+
+version=""
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$version" || -z "$output" ]]; then
+  usage
+  exit 2
+fi
+
+version="${version#v}"
+
+awk -v version="$version" '
+  /^## / {
+    if (in_section) {
+      exit
+    }
+    heading = $0
+    if (heading ~ "^## " version "( - |$)") {
+      in_section = 1
+      print heading
+      next
+    }
+  }
+  in_section { print }
+' CHANGELOG.md > "$output"
+
+if [[ ! -s "$output" ]]; then
+  {
+    echo "## $version"
+    echo ""
+    echo "See CHANGELOG.md for release details."
+  } > "$output"
+fi
+
+cat >> "$output" <<'NOTES'
+
+## Package
+
+This is a community-maintained PrintNode API client published as `printnode_community`.
+NOTES


### PR DESCRIPTION
## Summary
- create GitHub Releases after successful PyPI publishes
- extract release notes from the matching CHANGELOG.md section
- update the release process docs so GitHub Release creation is no longer manual

## Verification
- bash -n scripts/extract-changelog-release-notes.sh
- generated sample notes for v0.3.0
- git diff --check