### PR TITLE
Use github.json for workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -33,7 +33,10 @@
       "upstream compatibility changes"
     ]
   },
-  "importantWorkflows": ["CI", "Publish"],
+  "importantWorkflows": [
+    "CI",
+    "Publish"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [
@@ -65,7 +68,6 @@
     ]
   },
   "relatedRepos": [],
-  "validatedThrough": ["CI", "Publish"],
   "metadataFreshness": {
     "updateWhen": [
       "docs routing changes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository is maintained as a careful, community-oriented Python client for
 ## Branch and PR Rules
 
 - The default branch is `main`.
-- Keep repo workflow defaults in `.github/github-repo-workflow.json` so future
+- Keep repo workflow defaults in `.github/github.json` so future
   GitHub workflow sessions can discover non-secret repo workflow facts,
   validation commands, GitHub signal availability, docs routing, important
   workflows, and cleanup policy.
@@ -57,7 +57,7 @@ This repository is maintained as a careful, community-oriented Python client for
 
 ## Local Verification
 
-Use the canonical gates from `.github/github-repo-workflow.json`:
+Use the canonical gates from `.github/github.json`:
 
 ```sh
 uv sync --locked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for helping maintain this PrintNode API client. This fork aims to be c
 ## Development
 
 The project uses `pyproject.toml` and `uv`. Use the validation gates recorded
-in `.github/github-repo-workflow.json`:
+in `.github/github.json`:
 
 ```sh
 uv sync --locked

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,13 +2,13 @@
 
 The default test suite is credential-free and must not call the live PrintNode API.
 
-Run tests with the gate recorded in `.github/github-repo-workflow.json`:
+Run tests with the gate recorded in `.github/github.json`:
 
 ```sh
 uv run pytest
 ```
 
 For full package verification, follow the repository workflow metadata in
-`.github/github-repo-workflow.json`.
+`.github/github.json`.
 
 Live PrintNode API tests may be added later, but they must be opt-in and gated by explicit environment variables. Do not commit real API keys, account credentials, customer data, or live API fixtures.


### PR DESCRIPTION
## Summary
- rename repo workflow metadata from `.github/github-repo-workflow.json` to `.github/github.json`
- update local guidance/docs to point at the canonical metadata path
- drop retired `validatedThrough` metadata while preserving the rest of the workflow facts

## Validation
- `jq empty .github/github.json`
- confirmed `.github/github-repo-workflow.json` is removed
- confirmed repo docs no longer reference `.github/github-repo-workflow.json`
- confirmed `.github/github.json` has no `validatedThrough` / `validated-through` entries
- compared old and new JSON content, allowing only the retired `validatedThrough` field/trigger removal
- `git diff --check`
